### PR TITLE
Updated monit tar download URL

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -3,7 +3,8 @@
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
 #MONIT_DOWNLOAD_URL="http://mmonit.com/monit/dist/binary/5.6/monit-5.6-linux-x64.tar.gz"
-MONIT_DOWNLOAD_URL="http://mmonit.com/monit/dist/binary/5.8.1/monit-5.8.1-linux-x64.tar.gz"
+#MONIT_DOWNLOAD_URL="http://mmonit.com/monit/dist/binary/5.8.1/monit-5.8.1-linux-x64.tar.gz"
+MONIT_DOWNLOAD_URL="http://mmonit.com/monit/dist/binary/5.11/monit-5.11-linux-x64.tar.gz"
 
 # Download the precompiled monit binary
 #

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -36,4 +36,4 @@ Endpoints:
   - Frontend: '/monit-status'
     Backend: '/'
 
-Source-Url: https://github.com/robertoestivill/openshift-origin-cartridge-monit.git
+Source-Url: https://github.com/openshift-cartridges/openshift-origin-cartridge-monit.git

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -36,4 +36,4 @@ Endpoints:
   - Frontend: '/monit-status'
     Backend: '/'
 
-Source-Url: https://github.com/openshift-cartridges/openshift-origin-cartridge-monit.git
+Source-Url: https://github.com/robertoestivill/openshift-origin-cartridge-monit.git


### PR DESCRIPTION
This change should fix the issues reported on https://github.com/openshift-cartridges/openshift-origin-cartridge-monit/issues/4
